### PR TITLE
Fix doc about gtest/gmock.

### DIFF
--- a/docs/03-deplist.rst
+++ b/docs/03-deplist.rst
@@ -303,9 +303,9 @@ We rely on the https://docs.hunter.sh/en/latest/ project for the platform depend
 * gstreamer:
     - ``PkgConfig::gstreamer-1.0``
 * GTest:
-    - ``GTest::main) # GTest::gtest will be linked automatically``
-    - ``boo GTest::gtest``
-    - ``GMock::main``
+    - ``GTest::+gtest_main) # GTest::gtest will be linked automatically``
+    - ``GTest::+gtest``
+    - ``GMock::+gmock_main``
 * gumbo:
     - ``gumbo::gumbo``
 * h3:


### PR DESCRIPTION
Checking again nxxm works perfectly with [FTXUI]. I just had to add an
external dependency toward gtest. Everything work, except the nxxm
documentation was misleading. This patch updates it to give the
right exposed targets.

[FTXUI]: https://github.com/ArthurSonzogni/FTXUI